### PR TITLE
Add libtool to brew install hook

### DIFF
--- a/build/travis_run.sh
+++ b/build/travis_run.sh
@@ -5,15 +5,15 @@ set -e
 ./make.py > /dev/null
 if [ "$BUILDTYPE" == "osx-test" ]; then
     brew update
-    brew install libffi cppcheck openssl
+    brew install libffi cppcheck openssl libtool
     NOLIB=true sudo ./make.py test
 elif [ "$BUILDTYPE" == "osx-lib" ]; then
     brew update
-    brew install libffi cppcheck openssl
+    brew install libffi cppcheck openssl libtool
     NOLIB=false sudo ./make.py test-lib
 elif [ "$BUILDTYPE" == "osx-release" ]; then
     brew update
-    brew install libffi cppcheck openssl
+    brew install libffi cppcheck openssl libtool
     sudo python setup.py install
 else
     docker run -v $PWD:/outside adfinissygroup/chirp-jessie /bin/sh \


### PR DESCRIPTION
According to 1) libtool is missing what leads to a missing
file "ltmain.sh" within the libuv directory. Installing
libtool _should_ fix the issue.

1) https://www.gnu.org/software/automake/manual/html_node/Error-required-file-ltmain_002esh-not-found.html