### PR TITLE
Suppress cpp-check warnings about missing include files

### DIFF
--- a/build/project.make
+++ b/build/project.make
@@ -25,7 +25,7 @@ test_ext: coala cpp-check test-lib doc-all coverage
 doc-all: $(DOCRST) doc  ## Build using c2rst and then generate docs
 
 cpp-check:  ## Run cppcheck on the project
-	cppcheck -v --std=c99 -Iinclude -I$(LIBUVD)/include --config-exclude=$(LIBUVD)/include -D_SGLIB__h_ --error-exitcode=1 --inline-suppr --enable=warning,style,performance,portability,information,missingInclude src/
+	cppcheck -v --std=c99 -Iinclude -I$(LIBUVD)/include --config-exclude=$(LIBUVD)/include -D_SGLIB__h_ --error-exitcode=1 --inline-suppr --enable=warning,style,performance,portability,information,missingInclude --suppress=missingIncludeSystem src/
 
 ifeq ($(NOLIB),true)
 test-lib:

--- a/src/chirp.c
+++ b/src/chirp.c
@@ -152,6 +152,8 @@ ch_chirp_run(ch_config_t* config, ch_chirp_t** chirp_out)
     chirp._->auto_start = 1;
     L((&chirp), "UV-Loop %p run by chirp", &loop);
     /* This works and is not TOO bad because the function blocks. */
+    // cppcheck-suppress unmatchedSuppression
+    // cppcheck-suppress autoVariables
     *chirp_out = &chirp;
     tmp_err = ch_run(&loop);
     if(tmp_err != 0) {

--- a/src/chirp.c
+++ b/src/chirp.c
@@ -152,7 +152,6 @@ ch_chirp_run(ch_config_t* config, ch_chirp_t** chirp_out)
     chirp._->auto_start = 1;
     L((&chirp), "UV-Loop %p run by chirp", &loop);
     /* This works and is not TOO bad because the function blocks. */
-    // cppcheck-suppress autoVariables
     *chirp_out = &chirp;
     tmp_err = ch_run(&loop);
     if(tmp_err != 0) {

--- a/src/util.h
+++ b/src/util.h
@@ -71,6 +71,7 @@ _ch_random_ints_to_bytes(unsigned char* bytes, size_t len)
         bytes[i] = ((unsigned int) rand()) % 256;
     }
 #else // ACCEPT_STRANGE_PLATFORM
+// cppcheck-suppress preprocessorErrorDirective
 #error Unexpected RAND_MAX / INT_MAX, define CH_ACCEPT_STRANGE_PLATFORM
 #endif // ACCEPT_STRANGE_PLATFORM
 #else // RAND_MAX < 1073741824 || INT_MAX < 1073741824


### PR DESCRIPTION
Cpp-check seems not to be that good in finding default include
files, so it rants about not finding include files like errno.h
for example.

The option --suppress=missingIncludeSystem seems to solve the
problem. Another, imho maybe nicer option, would be to provide
the include directory by e.g. -I/usr/include. This solves the
problem at least under OS X and most likely under linux. For
windows although a conditional statement would be needed.